### PR TITLE
Fixed a non-deterministic test in MultiPartParserTest.java

### DIFF
--- a/src/test/java/ru/kalan/filereaderapp/MultiPartParserTest.java
+++ b/src/test/java/ru/kalan/filereaderapp/MultiPartParserTest.java
@@ -1,6 +1,7 @@
 package ru.kalan.filereaderapp;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -33,8 +34,11 @@ public class MultiPartParserTest {
             InputStream stream = new FileInputStream(file);
             Book book = MultiPartParser.createBook(stream);
             ObjectMapper mapper = new ObjectMapper();
-            String serialBook =  mapper.writeValueAsString(book);
-            Assertions.assertEquals(json, serialBook);
+
+            // Deserialize JSON strings to JsonNode objects for comparison
+            JsonNode tree1 = mapper.readTree(json);
+            JsonNode tree2 = mapper.readTree(mapper.writeValueAsString(book));
+            Assertions.assertEquals(tree1, tree2);
         } catch (FileNotFoundException | JsonProcessingException e) {
             e.printStackTrace();
         }

--- a/src/test/java/ru/kalan/filereaderapp/MultiPartParserTest.java
+++ b/src/test/java/ru/kalan/filereaderapp/MultiPartParserTest.java
@@ -34,8 +34,6 @@ public class MultiPartParserTest {
             InputStream stream = new FileInputStream(file);
             Book book = MultiPartParser.createBook(stream);
             ObjectMapper mapper = new ObjectMapper();
-
-            // Deserialize JSON strings to JsonNode objects for comparison
             JsonNode tree1 = mapper.readTree(json);
             JsonNode tree2 = mapper.readTree(mapper.writeValueAsString(book));
             Assertions.assertEquals(tree1, tree2);


### PR DESCRIPTION
### Issue: 
The createBook_ok test in MultiPartParserTest.java fails due to an assertCheck between two JSON Strings.

https://github.com/kal-an/file-reader-app/blob/ba6af3f33000ff1fcde9338922e55a7b1c374f99/src/test/java/ru/kalan/filereaderapp/MultiPartParserTest.java#L37

JSON string comparison is failing due to differences in the ordering of the JSON fields, you can compare the JSON objects in a way that doesn't rely on the order of fields. You can do this by parsing both the expected and actual JSON strings into JsonNode objects (provided by Jackson) and then comparing these objects.

### Fix:
Expected and Actual Strings can be converted into JsonNode Objects can be used to compare these objects. As this function compares the values inside the JSONObjects without needing order, the test becomes deterministic and ensures that the flakiness from the test is removed.

### Steps to reproduce the behavior:
I used an open-source tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex) to detect the assumption by shuffling the order of returned exception types.
Running the following commands will test the aforementioned operation

**Clone the Repo**
```
https://github.com/kal-an/file-reader-app.git 
```
**Compile the project**
```
mvn install -am -DskipTests
```
**(Optional) Run the unit test**
```
mvn test
```
**Run the unit test using NonDex**
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex
```

### Stack trace for additional information:
```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.027 s <<< FAILURE! - in ru.kalan.filereaderapp.MultiPartParserTest
[ERROR] createBook_ok  Time elapsed: 0.023 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <{"title":"GREATEST MAN IN ALIVE","chapters":[{"title":"Chapter one","description":"this story about awesome dude that call name is Jack","subChapter":{"title":"Jack's characteristics","property":{"weight":"190 pounds","height":"71 inch"}}},{"title":"Chapter two","description":"Jack was most famous man in alive his fame was greater than his popularity","subChapter":{"title":"Jack's patents","property":["mosquito net","x-ray","internal combustion engine"]}}]}> but was: <{"title":"GREATEST MAN IN ALIVE","chapters":[{"subChapter":{"title":"Jack's characteristics","property":{"weight":"190 pounds","height":"71 inch"}},"description":"this story about awesome dude that call name is Jack","title":"Chapter one"},{"subChapter":{"title":"Jack's patents","property":["mosquito net","x-ray","internal combustion engine"]},"description":"Jack was most famous man in alive his fame was greater than his popularity","title":"Chapter two"}]}>
        at ru.kalan.filereaderapp.MultiPartParserTest.createBook_ok(MultiPartParserTest.java:37)
```